### PR TITLE
Add Netlify security headers

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,8 @@
+/*
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  Referrer-Policy: no-referrer-when-downgrade
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Content-Security-Policy: default-src 'self'; script-src 'self'; object-src 'none';
+  Cross-Origin-Resource-Policy: same-origin


### PR DESCRIPTION
This pull request adds a _headers file to configure standard security headers for the site on Netlify. This includes HSTS, X-Frame-Options, CSP, and others to reduce common attack surfaces.